### PR TITLE
Fix null pointer exception on mystic door portals

### DIFF
--- a/src/argonms/game/field/GameMap.java
+++ b/src/argonms/game/field/GameMap.java
@@ -145,13 +145,23 @@ public class GameMap {
 		for (Map.Entry<Byte, PortalData> portal : stats.getPortals().entrySet())
 			if (portal.getValue().getPortalType() == 6)
 				mysticDoorSpots.add(portal.getKey());
+		// There are two maps that have less than 6 door spots in v62: Lith
+		// Harbor (104000000, 5 spots) and Haunted House (682000000, 3 spots).
+		// The latter may have issues with the door spawning on top of existing
+		// portals.
 		if (mysticDoorSpots.isEmpty()) {
 			mysticDoorPortalIds = null;
 		} else {
-			assert mysticDoorSpots.size() == 6;
 			mysticDoorPortalIds = new byte[6];
-			for (int i = 0; i < 6; i++)
-				mysticDoorPortalIds[i] = mysticDoorSpots.pollFirst().byteValue();
+			for (int i = 0; i < 6; i++) {
+				Byte mysticDoorPortalId = mysticDoorSpots.pollFirst();
+				if (mysticDoorPortalId != null) {
+					mysticDoorPortalIds[i] = mysticDoorPortalId;
+				} else {
+					// use the last portal for the remainder
+					mysticDoorPortalIds[i] = mysticDoorPortalIds[i-1];
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
Maps with less than 6 mystic door spots cannot be entered without this patch. This affects Lith Harbor in particular. To reproduce this issue:

```
docker-compose build && docker-compose up
# separate console, create a GM account
docker-compose run --rm center bin/insert_account.sh admin testing 101

# in game, in the chat box
!town lith harbor
```

Thanks BEN for the snippet to resolve this. This is the same issue in the [ragezone thread](http://forum.ragezone.com/f427/v62-maplestory-emulator-argonms-1153074/#post8995812).

I did some poking and found that [Haunted House](https://github.com/geospiza-fortis/wz-analysis/blob/main/notebooks/2020-12-13%20mystic%20door%20counts%20per%20map.ipynb) is the other map that would be affected by this.

