### PR TITLE
Enable the cash shop

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -10,3 +10,4 @@ SCRIPT_DIR=scripts/example/
 
 ## Dynamically configure properties files
 ARGONMS_GAME_0_HOST=localhost
+ARGONMS_SHOP_HOST=localhost

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The data for the server is persisted inside of a
 [volume](https://docs.docker.com/storage/volumes/). To inspect the contents:
 
 ```bash
-docker inspect argonms-server_argonms-volume
+docker volume inspect argonms-server_argonms-volume
 ```
 
 To delete all persisted data:

--- a/bin/launch_shop.sh
+++ b/bin/launch_shop.sh
@@ -32,4 +32,4 @@ mvn exec:java -Dexec.mainClass="argonms.shop.ShopServer" \
     -Dargonms.shop.blockedserials.file=$prefix/cashshopblockedserialnumbers.txt \
     -Dargonms.shop.commodityoverride.file=$prefix/cashshopcommodityoverrides.txt \
     -Dargonms.shop.limitedcommodity.file=$prefix/cashshoplimitedcommodities.txt \
-    -Dargonms.data.dir=${DATA_DIR}
+    -Dargonms.data.dir=${data_dir}

--- a/conf/testing/shop.properties
+++ b/conf/testing/shop.properties
@@ -17,7 +17,7 @@
 ##
 
 # External IP of this server
-argonms.shop.host=localhost
+argonms.shop.host=${env:ARGONMS_SHOP_HOST}
 
 # External port of this server
 argonms.shop.port=8787

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,6 +50,7 @@ services:
         bin/run_sql.sh < sql/argon.sql &&
         bin/run_sql.sh < sql/default_reactor_drops.sql &&
         bin/run_sql.sh < sql/default_shops.sql &&
+        bin/run_sql.sh < sql/default_cash_shop.sql &&
         bin/launch_center.sh
       "
   login:
@@ -91,3 +92,22 @@ services:
     ports:
       - "7575:7575"
     command: bash -c "sleep 15 && bin/launch_game.sh"
+  shop:
+    build:
+      context: .
+    restart: always
+    volumes:
+      - ./:/app
+      - $DATA_DIR:/app/wz
+      - /app/target
+    environment:
+      - MYSQL_USER
+      - MYSQL_PASSWORD
+      - MYSQL_DATABASE
+      - DATA_DIR=wz/
+    depends_on:
+      - center
+      - db
+    ports:
+      - "8787:8787"
+    command: bash -c "sleep 15 && bin/launch_shop.sh"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -105,6 +105,7 @@ services:
       - MYSQL_PASSWORD
       - MYSQL_DATABASE
       - DATA_DIR=wz/
+      - ARGONMS_SHOP_HOST=${ARGONMS_SHOP_HOST:-localhost}
     depends_on:
       - center
       - db

--- a/sql/default_cash_shop.sql
+++ b/sql/default_cash_shop.sql
@@ -20,12 +20,7 @@
 -- This script needs to be executed only if the shop server is enabled.
 --
 
-DROP TABLE IF EXISTS `cashshoplimitedcommodities`;
- DROP TABLE IF EXISTS `cashshopcouponusers`;
- DROP TABLE IF EXISTS `cashshopcouponitems`;
-DROP TABLE IF EXISTS `cashshopcoupons`;
-
-CREATE TABLE `cashshopcoupons` (
+CREATE TABLE IF NOT EXISTS `cashshopcoupons` (
   `entryid` INT(11) UNSIGNED NOT NULL AUTO_INCREMENT,
   `code` VARCHAR(65508) CHARACTER SET latin1 NOT NULL, /* InnoDB limit; client supports up to 65529 */
   `maplepoints` INT(11),
@@ -36,7 +31,7 @@ CREATE TABLE `cashshopcoupons` (
   UNIQUE KEY (`code`(767))
 ) ENGINE=InnoDB;
 
-CREATE TABLE `cashshopcouponitems` (
+CREATE TABLE IF NOT EXISTS `cashshopcouponitems` (
   `entryid` INT(11) UNSIGNED NOT NULL AUTO_INCREMENT,
   `couponentryid` INT(11) UNSIGNED,
   `sn` INT(11) NOT NULL,
@@ -45,7 +40,7 @@ CREATE TABLE `cashshopcouponitems` (
   CONSTRAINT FOREIGN KEY (`couponentryid`) REFERENCES `cashshopcoupons` (`entryid`) ON DELETE CASCADE
 ) ENGINE=InnoDB;
 
-CREATE TABLE `cashshopcouponusers` (
+CREATE TABLE IF NOT EXISTS `cashshopcouponusers` (
   `entryid` INT(11) UNSIGNED NOT NULL AUTO_INCREMENT,
   `couponentryid` INT(11) UNSIGNED,
   `accountid` INT(11) NOT NULL,
@@ -54,7 +49,7 @@ CREATE TABLE `cashshopcouponusers` (
   CONSTRAINT FOREIGN KEY (`couponentryid`) REFERENCES `cashshopcoupons` (`entryid`) ON DELETE CASCADE
 ) ENGINE=InnoDB;
 
-CREATE TABLE `cashshoplimitedcommodities` (
+CREATE TABLE IF NOT EXISTS `cashshoplimitedcommodities` (
   `entryid` INT(11) UNSIGNED NOT NULL AUTO_INCREMENT,
   `itemid` INT(11) NOT NULL,
   `used` INT(11) NOT NULL DEFAULT 0,

--- a/sql/default_cash_shop.sql
+++ b/sql/default_cash_shop.sql
@@ -20,6 +20,18 @@
 -- This script needs to be executed only if the shop server is enabled.
 --
 
+-- Keep track of cash for each account.
+CREATE TABLE IF NOT EXISTS `cashshopbalance` (
+  `entryid` INT(11) UNSIGNED NOT NULL AUTO_INCREMENT,
+  `accountid` INT(11) NOT NULL,
+  `paypalnx` INT(11) NOT NULL,
+  `maplepoints` INT(11) NOT NULL,
+  `gamecardnx` INT(11) NOT NULL,
+  PRIMARY KEY (`entryid`),
+  CONSTRAINT FOREIGN KEY (`accountid`) REFERENCES `accounts` (`id`) ON DELETE CASCADE,
+  UNIQUE (`accountid`)
+) ENGINE=InnoDB;
+
 CREATE TABLE IF NOT EXISTS `cashshopcoupons` (
   `entryid` INT(11) UNSIGNED NOT NULL AUTO_INCREMENT,
   `code` VARCHAR(65508) CHARACTER SET latin1 NOT NULL, /* InnoDB limit; client supports up to 65529 */

--- a/sql/default_cash_shop_drop_tables.sql
+++ b/sql/default_cash_shop_drop_tables.sql
@@ -1,0 +1,4 @@
+DROP TABLE IF EXISTS `cashshoplimitedcommodities`;
+DROP TABLE IF EXISTS `cashshopcouponusers`;
+DROP TABLE IF EXISTS `cashshopcouponitems`;
+DROP TABLE IF EXISTS `cashshopcoupons`;

--- a/sql/default_cash_shop_drop_tables.sql
+++ b/sql/default_cash_shop_drop_tables.sql
@@ -1,3 +1,4 @@
+DROP TABLE IF EXISTS `cashshopbalance`;
 DROP TABLE IF EXISTS `cashshoplimitedcommodities`;
 DROP TABLE IF EXISTS `cashshopcouponusers`;
 DROP TABLE IF EXISTS `cashshopcouponitems`;

--- a/src/argonms/shop/character/ShopCharacter.java
+++ b/src/argonms/shop/character/ShopCharacter.java
@@ -296,7 +296,6 @@ public class ShopCharacter extends LoggedInPlayer {
 		try {
 			// split this into two statements; one for increasing max characters
 			// and one for nx
-			con.setAutoCommit(false);
 			ps = con.prepareStatement("UPDATE `accounts` SET `characters` = ? WHERE `id` = ?");
 			ps.setByte(1, maxCharacters);
 			ps.setInt(2, client.getAccountId());
@@ -313,15 +312,8 @@ public class ShopCharacter extends LoggedInPlayer {
 			ps.executeUpdate();
 			con.commit();
 		} catch (SQLException e) {
-			try {
-				con.rollback();
-			} catch (SQLException eRollback) {
-				LOG.log(Level.WARNING, "Failed to rollback transaction on shop character save.");
-			} finally {
-				throw new SQLException("Failed to save account-info of character " + name, e);
-			}
+			throw new SQLException("Failed to save account-info of character " + name, e);
 		} finally {
-			con.setAutoCommit(true);
 			DatabaseManager.cleanup(DatabaseType.STATE, null, ps, null);
 		}
 	}
@@ -432,7 +424,7 @@ public class ShopCharacter extends LoggedInPlayer {
 		try {
 			con = DatabaseManager.getConnection(DatabaseType.STATE);
 			ps = con.prepareStatement("SELECT `c`.*,`a`.`name`,`a`.`characters`,`a`.`birthday`,"
-					+ "COALESCE(`a`.`paypalnx`,0) AS paypalnx,COALESCE(`a`.`maplepoints`,0) AS maplepoints, COALESCE(`a`.`gamecardnx`) as gamecardnx "
+					+ "COALESCE(`b`.`paypalnx`,0) AS paypalnx,COALESCE(`b`.`maplepoints`,0) AS maplepoints, COALESCE(`b`.`gamecardnx`) as gamecardnx "
 					+ "FROM `characters` `c` "
 					+ "LEFT JOIN `accounts` `a` ON `c`.`accountid` = `a`.`id` "
 					+ "LEFT JOIN `cashshopbalance` `b` ON `b`.`accountid` = `a`.`id`"


### PR DESCRIPTION
This adds a new `cashshopbalance` table that is used to keep track of the cash shop balance. These contain the columns that are missing from the upstream. This should allow the cash shop to stay an optional dependency and does not require modifying the accounts table.

