### PR TITLE
Fix caching of maven plugins

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,10 @@ FROM openjdk:8
 RUN apt-get update && \
     apt-get install -y maven default-mysql-client
 
-ENV HOME=/app
 WORKDIR /app
+# Cache plugins by calling help once before use
+# https://stackoverflow.com/a/39336178
+RUN mvn exec:help
 COPY pom.xml pom.xml
 RUN mvn dependency:go-offline
 ADD . /app


### PR DESCRIPTION
This reduces the amount of time it takes to spin up a new instance by caching the maven-exec-plugin. The container needs to be rebuilt when testing changes in the java code. 