### PR TITLE
Removed XML and WZ from enum as it's not supported.

### DIFF
--- a/conf/example/game0.properties
+++ b/conf/example/game0.properties
@@ -19,7 +19,7 @@
 # External IP of this server
 argonms.game.0.host=127.0.0.1
 
-# Valid types: KVJ, XML, WZ, MCDB
+# Valid types: KVJ, MCDB
 argonms.game.0.data.type=KVJ
 
 # Uses lots of memory at startup but reduces load when players are online

--- a/conf/example/game1.properties
+++ b/conf/example/game1.properties
@@ -19,7 +19,7 @@
 # External IP of this server
 argonms.game.1.host=127.0.0.1
 
-# Valid types: KVJ, XML, WZ, MCDB
+# Valid types: KVJ, MCDB
 argonms.game.1.data.type=KVJ
 
 # Uses lots of memory at startup but reduces load when players are online

--- a/conf/example/game2.properties
+++ b/conf/example/game2.properties
@@ -19,7 +19,7 @@
 # External IP of this server
 argonms.game.2.host=127.0.0.1
 
-# Valid types: KVJ, XML, WZ, MCDB
+# Valid types: KVJ, MCDB
 argonms.game.2.data.type=KVJ
 
 # Uses lots of memory at startup but reduces load when players are online

--- a/src/argonms/common/loading/DataFileType.java
+++ b/src/argonms/common/loading/DataFileType.java
@@ -23,5 +23,5 @@ package argonms.common.loading;
  * @author GoldenKevin
  */
 public enum DataFileType {
-	KVJ, XML, WZ, MCDB
+	KVJ, MCDB
 }


### PR DESCRIPTION
This PR removes the ability to select XML or WZ for reading data.
Close #2 